### PR TITLE
refactor: updating mint contract

### DIFF
--- a/contracts/src/contract-SEQ.js
+++ b/contracts/src/contract-SEQ.js
@@ -1,3 +1,4 @@
+import { env } from "./smartweave.js";
 import { balance } from "./read/balance.js";
 import { transfer } from "./write/transfer.js";
 import { allow } from "./write/allow.js";
@@ -10,7 +11,7 @@ export async function handle(state, action) {
     case "balance":
       return await balance(state, action);
     case "mint":
-      return mint(state, action);
+      return mint(env)(state, action).toPromise();
     case "transfer":
       return await transfer(state, action);
     case "allow":

--- a/contracts/src/smartweave.js
+++ b/contracts/src/smartweave.js
@@ -16,7 +16,7 @@
  */
 
 export const env = {
-  // readContractState: SmartWeave.contracts.readContractState.bind(SmartWeave),
+  readContractState: SmartWeave.contracts.readContractState.bind(SmartWeave),
   // write: SmartWeave.contracts.write.bind(SmartWeave),
   block: SmartWeave.block,
   transaction: SmartWeave.transaction,

--- a/contracts/src/write/transfer.js
+++ b/contracts/src/write/transfer.js
@@ -1,4 +1,4 @@
-import { assoc, identity, __ } from "ramda";
+import { assoc, identity, __, pick } from "ramda";
 
 import { fromNullable, of } from "../hyper-either.js";
 import {
@@ -10,37 +10,40 @@ import {
 } from "../util.js";
 
 export function transfer(state, action) {
-  return of({ state, action })
-    .chain(fromNullable)
-    .chain(ce(!action.input?.target, "Please specify a target."))
-    .chain(
-      ce(action.input?.target === action.caller, "Target cannot be caller.")
-    )
-    .chain(
-      ce(
-        !isInteger(state.balances[action.caller]),
-        "Caller does not have a balance."
+  return (
+    of({ state, action })
+      .chain(fromNullable)
+      .chain(ce(!action.input?.target, "Please specify a target."))
+      .chain(
+        ce(action.input?.target === action.caller, "Target cannot be caller.")
       )
-    )
-    .chain(ce(!isInteger(action.input?.qty), "qty must be an integer."))
-    .chain(
-      ce(
-        action.input?.qty < 1,
-        "Invalid token transfer. qty must be an integer greater than 0."
+      .chain(
+        ce(
+          !isInteger(state.balances[action.caller]),
+          "Caller does not have a balance."
+        )
       )
-    )
-    .chain(
-      ce(
-        state.balances[action.caller] < action.input?.qty,
-        "Not enough tokens for transfer."
+      .chain(ce(!isInteger(action.input?.qty), "qty must be an integer."))
+      .chain(
+        ce(
+          action.input?.qty < 1,
+          "Invalid token transfer. qty must be an integer greater than 0."
+        )
       )
-    )
-    .map(setTargetBalance)
-    .map(subtractCallerBalance)
-    .map(addTargetBalance)
-    .map(({ state }) => state)
-    .map(assoc("state", __, {}))
-    .fold((msg) => {
-      throw new ContractError(msg || "An error occurred.");
-    }, identity);
+      .chain(
+        ce(
+          state.balances[action.caller] < action.input?.qty,
+          "Not enough tokens for transfer."
+        )
+      )
+      .map(setTargetBalance)
+      .map(subtractCallerBalance)
+      .map(addTargetBalance)
+      .map(pick(["state"]))
+      // .map(({ state }) => state)
+      // .map(assoc("state", __, {}))
+      .fold((msg) => {
+        throw new ContractError(msg || "An error occurred.");
+      }, identity)
+  );
 }

--- a/contracts/test/mint.test.js
+++ b/contracts/test/mint.test.js
@@ -4,7 +4,7 @@ import { mint } from "../src/write/mint.js";
 import { setupSmartWeaveEnv } from "./setup.js";
 const test = suite("mint");
 
-test.before(async () => {});
+test.before(async () => { });
 
 test("should not mint bar with reward lower than 1M", async () => {
   // set reward to 10
@@ -59,12 +59,12 @@ test("should not mint bar with reward lower than 1M", async () => {
       pile: ["processed"],
     },
     { caller }
-  );
+  ).toPromise();
   const state = output.state;
   assert.is(state.balances["<jshaw>"], 5);
   assert.is(state.pile.filter((v) => v === "processed").length, 1);
 });
 
-test.after(async () => {});
+test.after(async () => { });
 
 test.run();


### PR DESCRIPTION
Reviewing split contract and the mint function and made some recommendations and added some comments/questions about some of the functions. I did combine the mint function in a single pipe, ideally you should not call fork or toPromise until the edge of the pipe, so I remove the forks functions and added toPromise in the SEQ contract. 

`toPromise` is the same as calling fork, but if an error occurs it will throw in the SEQ, so you could just let it throw.